### PR TITLE
Fix deprecation warning of newer Visual Studio versions

### DIFF
--- a/shared/DSPFilters/include/DspFilters/Common.h
+++ b/shared/DSPFilters/include/DspFilters/Common.h
@@ -57,11 +57,4 @@ THE SOFTWARE.
 #include <vector>
 #include <algorithm>
 
-#ifdef _MSC_VER
-namespace tr1 = std::tr1;
-#else
-namespace tr1 = std;
-#endif
-
-
 #endif

--- a/shared/DSPFilters/include/DspFilters/Utilities.h
+++ b/shared/DSPFilters/include/DspFilters/Utilities.h
@@ -529,7 +529,7 @@ void zero (int samples,
            Ty* dest,
            int destSkip = 0)
 {
-  detail::zero<Ty, tr1::is_pod<Ty>::value>::process (samples, dest, destSkip );
+  detail::zero<Ty, std::is_pod<Ty>::value>::process (samples, dest, destSkip );
 }
 
 #else


### PR DESCRIPTION
This gets rid of compilation warnings emitted by newer Visual Studio versions that have support for `std::is_pod`.